### PR TITLE
Remove error background from stack trace

### DIFF
--- a/src/components/logs/LogEntry.tsx
+++ b/src/components/logs/LogEntry.tsx
@@ -47,7 +47,7 @@ export const LogEntryComponent: React.FC<{ log: LogEntryType; use24Hour?: boolea
             </pre>
           )}
           {log.stack && (
-            <div className="mt-2 p-2 bg-red-50 rounded text-sm overflow-x-auto font-mono">
+            <div className="mt-2 p-2 rounded text-sm overflow-x-auto font-mono">
               {log.stack}
             </div>
           )}


### PR DESCRIPTION
This pull request includes a small change to the `LogEntryComponent` in the `src/components/logs/LogEntry.tsx` file. The change removes the `bg-red-50` class from the `div` element that displays the log stack, simplifying the component's styling.